### PR TITLE
Sign out alert when I sign out

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
+  config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete


### PR DESCRIPTION
When I sign out, we can now see the alert "Successfully signed out", which was not showing before. 
Added  config.navigational_formats = ['*/*', :html, :turbo_stream] to devise.rb
Otherwise, was not reloading the html 
