### PR TITLE
Edit orders page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 @import "components/cards";
 @import "pages/index";
 @import "components/cardshow";
+@import "pages/orders_index";
 
 // font
 @import url('https://fonts.googleapis.com/css2?family=Cabin:wght@700&family=Josefin+Sans:wght@600&family=Jost:wght@500&family=Roboto+Flex:wght@300&family=Source+Code+Pro&display=swap');

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,10 +32,6 @@ body {
   margin: auto;
 }
 
-.table {
-  background-color: #ffe8e2;
-}
-
 .btn-submit  {
   background-color: #FFDED6;
   color: black;
@@ -56,4 +52,8 @@ body {
   margin-top:50px;
   height:50px;
 
+}
+
+.container {
+  width: 95%;
 }

--- a/app/assets/stylesheets/pages/_orders_index.scss
+++ b/app/assets/stylesheets/pages/_orders_index.scss
@@ -2,3 +2,11 @@
   color: rgb(163, 163, 163);
   font-size: 0.8rem;
 }
+
+.edit-link:hover {
+  cursor: pointer;
+}
+
+.table {
+  table-layout: fixed;
+}

--- a/app/assets/stylesheets/pages/_orders_index.scss
+++ b/app/assets/stylesheets/pages/_orders_index.scss
@@ -9,10 +9,11 @@
 
 .table {
   table-layout: fixed;
+  background-color: #ffe8e2;
 }
 
 tr:nth-of-type(2n+1) {
-  background-color: #f8dad2;
+  background-color: #ffded6;
 }
 
 td {

--- a/app/assets/stylesheets/pages/_orders_index.scss
+++ b/app/assets/stylesheets/pages/_orders_index.scss
@@ -19,3 +19,7 @@ tr:nth-of-type(2n+1) {
 td {
   font-weight: 300;
 };
+
+tr a {
+  color: black;
+}

--- a/app/assets/stylesheets/pages/_orders_index.scss
+++ b/app/assets/stylesheets/pages/_orders_index.scss
@@ -1,0 +1,4 @@
+.edit-link {
+  color: rgb(163, 163, 163);
+  font-size: 0.8rem;
+}

--- a/app/assets/stylesheets/pages/_orders_index.scss
+++ b/app/assets/stylesheets/pages/_orders_index.scss
@@ -10,3 +10,11 @@
 .table {
   table-layout: fixed;
 }
+
+tr:nth-of-type(2n+1) {
+  background-color: #f8dad2;
+}
+
+td {
+  font-weight: 300;
+};

--- a/app/javascript/controllers/display_buttons_controller.js
+++ b/app/javascript/controllers/display_buttons_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['initial', 'buttons']
+
+  connect() {
+    console.log("Hello from Stimulus controller")
+  }
+
+  display() {
+    this.initialTarget.classList.add('d-none');
+    this.buttonsTarget.classList.remove('d-none');
+  }
+}

--- a/app/javascript/controllers/edit_comment_controller.js
+++ b/app/javascript/controllers/edit_comment_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="edit-comment"
+export default class extends Controller {
+  static targets = ['initial', 'field']
+
+  connect() {
+  }
+
+  display() {
+    this.initialTarget.classList.add('d-none');
+    this.fieldTarget.classList.remove('d-none');
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,11 @@
 
 import { application } from "./application"
 
+import DisplayButtonsController from "./display_buttons_controller"
+application.register("display-buttons", DisplayButtonsController)
+
+import EditCommentController from "./edit_comment_controller"
+application.register("edit-comment", EditCommentController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,7 @@
   <body>
     <%= render "shared/navbar" %>
     <%= yield %>
-        <%= render "shared/footer" %>
-
+    <%= render "shared/footer" %>
     <%= render "shared/flashes" %>
-    <%= yield %>
   </body>
 </html>

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="card-body mt-1">
         <h5 class="card-title"><%= meal.name %></h5>
-        <h6 class="bottom-right">$<%= meal.price %></h6>
+        <h6 class="bottom-right">$<%= sprintf('%.2f', meal.price) %></h6>
       </div>
     </div>
   <% end %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="index-container wrap">
   <h2 class="page-title">Your Orders</h2 class="page-title">
 
   <h3 class="mb-3">Purchases</h3>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -38,7 +38,7 @@
         <th>Date Ordered</th>
         <th>Name of Buyer</th>
         <th>Order Status</th>
-        <th>Change Status</th>
+        <th>My Comments</th>
       </tr>
       <% @sales.each do |order| %>
         <tr>
@@ -46,40 +46,8 @@
           <td><%= order.meal.name %></td>
           <td><%= order.created_at.strftime('%d/%m/%Y') %></td>
           <td><%= "#{order.buyer.first_name} #{order.buyer.last_name}" %></td>
-          <td><%= order.status.capitalize %></td>
+          <td><%= order.status.capitalize %> <i class="fa-solid fa-pen-to-square edit-link"></i></td>
           <td>
-            <% if ['completed', 'rejected'].exclude? order.status %>
-              <%#= simple_form_for order, html: { class: "row row-cols-5 g-2 align-items-center" } do |f| %>
-                <%#= f.label :status, class: "col-auto" %>
-                <% if order.status == 'pending' %>
-
-                  <%= simple_form_for order do |f| %>
-                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
-                    <%= f.button :submit, 'Accept' %>
-                  <% end %>
-                  <%= simple_form_for order do |f| %>
-                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
-                    <%= f.button :submit, 'Reject' %>
-                  <% end %>
-                  <%#= f.input_field :status, collection: %w[pending accepted rejected], class: "col-auto me-2" %>
-
-                <% elsif  order.status == 'accepted' %>
-                  <%= simple_form_for order do |f| %>
-                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
-                    <%= f.button :submit, 'Accept' %>
-                  <% end %>
-                  <%= simple_form_for order do |f| %>
-                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
-                    <%= f.button :submit, 'Accept' %>
-                  <% end %>
-                  <%#= f.input_field :status, collection: %w[accepted completed], class: "col-auto me-2" %>
-
-                <% end %>
-                <%= f.label :comment, class: "col-auto" %>
-                <%= f.input_field :comment, class: "col-auto me-2" %>
-                <%= f.button :submit, class: "col-auto btn btn-light border border-dark border-1" %>
-              <%# end %>
-            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,7 +5,7 @@
   <% if @purchases.empty? %>
     <p>You have no purchases.</p>
   <% else %>
-    <table class="table table-bordered border-2 border-white align-middle">
+    <table class="table table-bordered border-2 border-white table-striped align-middle">
       <tr>
         <th scope="col" style="width: 7%">Order Id</th>
         <th scope="col" style="width: 30%">Name of Meal</th>
@@ -32,7 +32,7 @@
     <p>You have no sales.</p>
   <% else %>
     <div class="table-responsive-md">
-      <table class="table table-bordered border-2 border-white align-middle">
+      <table class="table table-bordered border-2 border-white table-striped align-middle">
         <tr>
           <th style="width: 7%">Order Id</th>
           <th style="width: 21%">Name of Meal</th>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,13 +5,13 @@
   <% if @purchases.empty? %>
     <p>You have no purchases.</p>
   <% else %>
-    <table class="table table-bordered border-2 border-white table-striped align-middle">
+    <table class="table table-bordered border-2 border-white align-middle">
       <tr>
-        <th scope="col" style="width: 7%">Order Id</th>
-        <th scope="col" style="width: 30%">Name of Meal</th>
-        <th scope="col" style="width: 17%">Date Ordered</th>
-        <th scope="col" style="width: 16%">Order Status</th>
-        <th scope="col" style="width: 30%">Seller's Comments</th>
+        <th scope="col" style="width: 7%" class="extra-bold">Order Id</th>
+        <th scope="col" style="width: 30%" class="extra-bold">Name of Meal</th>
+        <th scope="col" style="width: 17%" class="extra-bold">Date Ordered</th>
+        <th scope="col" style="width: 16%" class="extra-bold">Order Status</th>
+        <th scope="col" style="width: 30%" class="extra-bold">Seller's Comments</th>
       </tr>
       <% @purchases.each do |order| %>
         <tr>
@@ -32,14 +32,14 @@
     <p>You have no sales.</p>
   <% else %>
     <div class="table-responsive-md">
-      <table class="table table-bordered border-2 border-white table-striped align-middle">
+      <table class="table table-bordered border-2 border-white align-middle">
         <tr>
-          <th style="width: 7%">Order Id</th>
-          <th style="width: 21%">Name of Meal</th>
-          <th style="width: 17%">Date Ordered</th>
-          <th style="width: 17%">Name of Buyer</th>
-          <th style="width: 17%">Order Status</th>
-          <th style="width: 21%">Comments to Buyer</th>
+          <th class="extra-bold" style="width: 7%">Order Id</th>
+          <th class="extra-bold" style="width: 21%">Name of Meal</th>
+          <th class="extra-bold" style="width: 17%">Date Ordered</th>
+          <th class="extra-bold" style="width: 17%">Name of Buyer</th>
+          <th class="extra-bold" style="width: 17%">Order Status</th>
+          <th class="extra-bold" style="width: 21%">Comments to Buyer</th>
         </tr>
         <% @sales.each do |order| %>
           <tr>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -16,7 +16,7 @@
       <% @purchases.each do |order| %>
         <tr>
           <td><%= order.id %></td>
-          <td><%= order.meal.name %></td>
+          <td><%= link_to order.meal.name, meal_path(order.meal) %></td>
           <td><%= order.created_at.strftime('%d/%m/%Y') %></td>
           <td><%= order.status.capitalize %></td>
           <td><%= order.comment %></td>
@@ -49,17 +49,36 @@
           <td><%= order.status.capitalize %></td>
           <td>
             <% if ['completed', 'rejected'].exclude? order.status %>
-              <%= simple_form_for order, html: { class: "row row-cols-5 g-2 align-items-center" } do |f| %>
-                <%= f.label :status, class: "col-auto" %>
+              <%#= simple_form_for order, html: { class: "row row-cols-5 g-2 align-items-center" } do |f| %>
+                <%#= f.label :status, class: "col-auto" %>
                 <% if order.status == 'pending' %>
-                  <%= f.input_field :status, collection: %w[pending accepted rejected], class: "col-auto me-2" %>
+
+                  <%= simple_form_for order do |f| %>
+                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
+                    <%= f.button :submit, 'Accept' %>
+                  <% end %>
+                  <%= simple_form_for order do |f| %>
+                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
+                    <%= f.button :submit, 'Reject' %>
+                  <% end %>
+                  <%#= f.input_field :status, collection: %w[pending accepted rejected], class: "col-auto me-2" %>
+
                 <% elsif  order.status == 'accepted' %>
-                  <%= f.input_field :status, collection: %w[accepted completed], class: "col-auto me-2" %>
+                  <%= simple_form_for order do |f| %>
+                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
+                    <%= f.button :submit, 'Accept' %>
+                  <% end %>
+                  <%= simple_form_for order do |f| %>
+                    <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
+                    <%= f.button :submit, 'Accept' %>
+                  <% end %>
+                  <%#= f.input_field :status, collection: %w[accepted completed], class: "col-auto me-2" %>
+
                 <% end %>
                 <%= f.label :comment, class: "col-auto" %>
                 <%= f.input_field :comment, class: "col-auto me-2" %>
                 <%= f.button :submit, class: "col-auto btn btn-light border border-dark border-1" %>
-              <% end %>
+              <%# end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,11 +7,11 @@
   <% else %>
     <table class="table table-bordered border-2 border-white align-middle">
       <tr>
-        <th scope="col">Order Id</th>
-        <th scope="col">Name of Meal</th>
-        <th scope="col">Date Ordered</th>
-        <th scope="col">Order Status</th>
-        <th scope="col">Seller's Comments</th>
+        <th scope="col" style="width: 7%">Order Id</th>
+        <th scope="col" style="width: 30%">Name of Meal</th>
+        <th scope="col" style="width: 17%">Date Ordered</th>
+        <th scope="col" style="width: 16%">Order Status</th>
+        <th scope="col" style="width: 30%">Seller's Comments</th>
       </tr>
       <% @purchases.each do |order| %>
         <tr>
@@ -31,27 +31,69 @@
   <% if @sales.empty? %>
     <p>You have no sales.</p>
   <% else %>
-    <table class="table table-bordered border-2 border-white align-middle">
-      <tr>
-        <th>Order Id</th>
-        <th>Name of Meal</th>
-        <th>Date Ordered</th>
-        <th>Name of Buyer</th>
-        <th>Order Status</th>
-        <th>My Comments</th>
-      </tr>
-      <% @sales.each do |order| %>
+    <div class="table-responsive-md">
+      <table class="table table-bordered border-2 border-white align-middle">
         <tr>
-          <td><%= order.id %></td>
-          <td><%= order.meal.name %></td>
-          <td><%= order.created_at.strftime('%d/%m/%Y') %></td>
-          <td><%= "#{order.buyer.first_name} #{order.buyer.last_name}" %></td>
-          <td><%= order.status.capitalize %> <i class="fa-solid fa-pen-to-square edit-link"></i></td>
-          <td>
-          </td>
+          <th style="width: 7%">Order Id</th>
+          <th style="width: 21%">Name of Meal</th>
+          <th style="width: 17%">Date Ordered</th>
+          <th style="width: 17%">Name of Buyer</th>
+          <th style="width: 17%">Order Status</th>
+          <th style="width: 21%">Comments to Buyer</th>
         </tr>
-      <% end %>
-    </table>
+        <% @sales.each do |order| %>
+          <tr>
+            <td><%= order.id %></td>
+            <td><%= order.meal.name %></td>
+            <td><%= order.created_at.strftime('%d/%m/%Y') %></td>
+            <td><%= "#{order.buyer.first_name} #{order.buyer.last_name}" %></td>
+            <td data-controller="display-buttons">
+              <span data-display-buttons-target="initial">
+                <%= order.status.capitalize %>
+                <% if ['completed', 'rejected'].exclude? order.status %>
+                  <i data-action="click->display-buttons#display" class="fa-solid fa-pen-to-square edit-link"></i>
+                <% end %>
+              </span>
+              <div data-display-buttons-target="buttons" class="d-none">
+                <div class="d-flex">
+                <% if order.status == 'pending' %>
+
+                    <%= simple_form_for order, html: { class: "d-flex align-items-center me-2" } do |f| %>
+                      <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
+                      <%= f.button :submit, 'Accept', class: "btn btn-success" %>
+                    <% end %>
+                    <%= simple_form_for order, html: { class: "d-flex align-items-center" } do |f| %>
+                      <%= f.input :status, as: :hidden, input_html: { value: 'rejected'} %>
+                      <%= f.button :submit, 'Reject', class: "btn btn-danger" %>
+                    <% end %>
+                  </div>
+
+                <% elsif  order.status == 'accepted' %>
+
+                  <%= simple_form_for order, html: { class: "d-flex align-items-center me-2" } do |f| %>
+                    <%= f.input :status, as: :hidden, input_html: { value: 'completed'} %>
+                    <%= f.button :submit, 'Mark as completed', class: "btn btn-primary" %>
+                  <% end %>
+
+                <% end %>
+              </div>
+              </td>
+            <td data-controller="edit-comment">
+              <span data-edit-comment-target="initial">
+                <%= order.comment %>
+                <i data-action="click->edit-comment#display" class="fa-solid fa-pen-to-square edit-link"></i>
+              </span>
+              <div data-edit-comment-target="field" class="d-none">
+                <%= simple_form_for order, html: { class: "d-flex align-items-center" } do |f| %>
+                  <%= f.input_field :comment %>
+                  <%= f.button :submit, class: "d-none" %>
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
   <% end %>
   <br>
 </div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,16 +7,18 @@
   <% else %>
     <table class="table table-bordered border-2 border-white align-middle">
       <tr>
-        <th scope="col" style="width: 7%" class="extra-bold">Order Id</th>
-        <th scope="col" style="width: 30%" class="extra-bold">Name of Meal</th>
-        <th scope="col" style="width: 17%" class="extra-bold">Date Ordered</th>
-        <th scope="col" style="width: 16%" class="extra-bold">Order Status</th>
-        <th scope="col" style="width: 30%" class="extra-bold">Seller's Comments</th>
+        <th scope="col" style="width: 8%">Order Id</th>
+        <th scope="col" style="width: 29%">Name of Meal</th>
+        <th scope="col" style="width: 11%">Price</th>
+        <th scope="col" style="width: 11%">Date Ordered</th>
+        <th scope="col" style="width: 11%">Order Status</th>
+        <th scope="col" style="width: 30%">Seller's Comments</th>
       </tr>
       <% @purchases.each do |order| %>
         <tr>
           <td><%= order.id %></td>
           <td><%= link_to order.meal.name, meal_path(order.meal) %></td>
+          <td>$<%= sprintf('%.2f', order.meal.price) %></td>
           <td><%= order.created_at.strftime('%d/%m/%Y') %></td>
           <td><%= order.status.capitalize %></td>
           <td><%= order.comment %></td>
@@ -34,17 +36,19 @@
     <div class="table-responsive-md">
       <table class="table table-bordered border-2 border-white align-middle">
         <tr>
-          <th class="extra-bold" style="width: 7%">Order Id</th>
-          <th class="extra-bold" style="width: 21%">Name of Meal</th>
-          <th class="extra-bold" style="width: 17%">Date Ordered</th>
-          <th class="extra-bold" style="width: 17%">Name of Buyer</th>
-          <th class="extra-bold" style="width: 17%">Order Status</th>
-          <th class="extra-bold" style="width: 21%">Comments to Buyer</th>
+          <th style="width: 8%">Order Id</th>
+          <th style="width: 22%">Name of Meal</th>
+          <th style="width: 8%">Price</th>
+          <th style="width: 12%">Date Ordered</th>
+          <th style="width: 12%">Name of Buyer</th>
+          <th style="width: 15%">Order Status</th>
+          <th style="width: 23%">Comments to Buyer</th>
         </tr>
         <% @sales.each do |order| %>
           <tr>
             <td><%= order.id %></td>
-            <td><%= order.meal.name %></td>
+            <td><%= link_to order.meal.name, meal_path(order.meal) %></td>
+            <td>$<%= sprintf('%.2f', order.meal.price) %></td>
             <td><%= order.created_at.strftime('%d/%m/%Y') %></td>
             <td><%= "#{order.buyer.first_name} #{order.buyer.last_name}" %></td>
             <td data-controller="display-buttons">
@@ -54,25 +58,24 @@
                   <i data-action="click->display-buttons#display" class="fa-solid fa-pen-to-square edit-link"></i>
                 <% end %>
               </span>
-              <div data-display-buttons-target="buttons" class="d-none">
-                <div class="d-flex">
+              <div data-display-buttons-target="buttons" class="d-none d-flex flex-wrap">
                 <% if order.status == 'pending' %>
 
-                    <%= simple_form_for order, html: { class: "d-flex align-items-center me-2" } do |f| %>
+                    <%= simple_form_for order, html: { class: "d-flex align-items-center m-1" } do |f| %>
                       <%= f.input :status, as: :hidden, input_html: { value: 'accepted'} %>
-                      <%= f.button :submit, 'Accept', class: "btn btn-success" %>
+                      <%= f.button :submit, 'Accept', class: "btn btn-success btn-sm" %>
                     <% end %>
-                    <%= simple_form_for order, html: { class: "d-flex align-items-center" } do |f| %>
+                    <%= simple_form_for order, html: { class: "d-flex align-items-center m-1" } do |f| %>
                       <%= f.input :status, as: :hidden, input_html: { value: 'rejected'} %>
-                      <%= f.button :submit, 'Reject', class: "btn btn-danger" %>
+                      <%= f.button :submit, 'Reject', class: "btn btn-danger btn-sm" %>
                     <% end %>
-                  </div>
+
 
                 <% elsif  order.status == 'accepted' %>
 
                   <%= simple_form_for order, html: { class: "d-flex align-items-center me-2" } do |f| %>
                     <%= f.input :status, as: :hidden, input_html: { value: 'completed'} %>
-                    <%= f.button :submit, 'Mark as completed', class: "btn btn-primary" %>
+                    <%= f.button :submit, 'Mark as completed', class: "btn btn-primary btn-sm" %>
                   <% end %>
 
                 <% end %>


### PR DESCRIPTION
- Added links to the respective meal show page 
- Added column for price
- Forms to update the status/add comments will only display upon clicking the edit icon, instead of rendering upon load
- Fixed widths of the columns so that they won't keep changing when the forms appear
- Added striping to the tables

Currently the comment can be edited regardless of the status (status can only be edited if it's not 'Completed' or 'Rejected'). Any disagreements with this?

<img width="924" alt="image" src="https://user-images.githubusercontent.com/114224311/202645395-145d7eb5-1732-4a08-a665-a2197717929e.png">
